### PR TITLE
Remove redundant indexes in MySQL DB schema

### DIFF
--- a/zipkin-anormdb/src/main/resources/mysql.sql
+++ b/zipkin-anormdb/src/main/resources/mysql.sql
@@ -6,11 +6,9 @@ CREATE TABLE IF NOT EXISTS zipkin_spans (
   `debug` BIT(1),
   `start_ts` BIGINT COMMENT 'Span.timestamp(): epoch micros used for endTs query and to implement TTL',
   `duration` BIGINT COMMENT 'Span.duration(): micros used for minDuration and maxDuration query'
-) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED;
 
 ALTER TABLE zipkin_spans ADD UNIQUE KEY(`trace_id`, `id`) COMMENT 'ignore insert on duplicate';
-ALTER TABLE zipkin_spans ADD INDEX(`trace_id`, `id`) COMMENT 'for joining with zipkin_annotations';
-ALTER TABLE zipkin_spans ADD INDEX(`trace_id`) COMMENT 'for getTracesByIds';
 ALTER TABLE zipkin_spans ADD INDEX(`name`) COMMENT 'for getTraces and getSpanNames';
 ALTER TABLE zipkin_spans ADD INDEX(`start_ts`) COMMENT 'for getTraces ordering and range';
 
@@ -23,12 +21,10 @@ CREATE TABLE IF NOT EXISTS zipkin_annotations (
   `a_timestamp` BIGINT COMMENT 'Used to implement TTL; Annotation.timestamp or zipkin_spans.timestamp',
   `endpoint_ipv4` INT COMMENT 'Null when Binary/Annotation.endpoint is null',
   `endpoint_port` SMALLINT COMMENT 'Null when Binary/Annotation.endpoint is null',
-  `endpoint_service_name` VARCHAR(255) COMMENT 'Null when Binary/Annotation.endpoint is null'
-) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
+  `endpoint_service_name` VARCHAR(255) COMMENT 'Null when Binary/Annotation.endpoint is null',
+  PRIMARY KEY(`trace_id`, `span_id`, `a_key`, `a_timestamp`) COMMENT 'Ignore insert on duplicate'
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED;
 
-ALTER TABLE zipkin_annotations ADD UNIQUE KEY(`trace_id`, `span_id`, `a_key`, `a_timestamp`) COMMENT 'Ignore insert on duplicate';
-ALTER TABLE zipkin_annotations ADD INDEX(`trace_id`, `span_id`) COMMENT 'for joining with zipkin_spans';
-ALTER TABLE zipkin_annotations ADD INDEX(`trace_id`) COMMENT 'for getTraces/ByIds';
 ALTER TABLE zipkin_annotations ADD INDEX(`endpoint_service_name`) COMMENT 'for getTraces and getServiceNames';
 ALTER TABLE zipkin_annotations ADD INDEX(`a_type`) COMMENT 'for getTraces';
 ALTER TABLE zipkin_annotations ADD INDEX(`a_key`) COMMENT 'for getTraces';


### PR DESCRIPTION
- Removes unnecessary indexes: InnoDB includes the primary key in all secondary indexes.  A few of
  the indexes defined in this schema were either a subset or a duplicate of the primary key.
- Adds explicit primary key to `zipkin_annotations` to avoid duplicate GEN_CLUST_INDEX:  According to the MySQL docs, if a primary key is not defined "MySQL locates the first UNIQUE index where all the key columns are NOT NULL and InnoDB uses it as the clustered index."  `zipkin_annotations` defines a unique index however the index contains a NULL column, so MySQL does NOT use it as the primary key. As a result, a GEN_CLUST_INDEX is created alongside the UNIQUE index.  The redundant index can be eliminated if the unique index is instead defined as a primary key.
